### PR TITLE
Switch chatbot to Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Required API keys
+PINECONE_API_KEY=your-pinecone-api-key
+GOOGLE_API_KEY=your-google-api-key
+
+# Optional Gemini configuration
+# GEMINI_MODEL=gemini-1.5-flash
+# GEMINI_TEMPERATURE=0.2
+# GEMINI_SAFETY_SETTINGS={"HARASSMENT":"BLOCK_NONE"}

--- a/README.md
+++ b/README.md
@@ -24,12 +24,19 @@ conda activate medibot
 pip install -r requirements.txt
 ```
 
+> The requirements file includes the Gemini client libraries (`langchain-google-genai` and `google-generativeai`) needed for the new chat model. Ensure your Python environment can install these packages before continuing.
 
-### Create a `.env` file in the root directory and add your Pinecone & openai credentials as follows:
+
+### Create a `.env` file in the root directory and add your Pinecone & Gemini credentials as follows (see `.env.example` for a template):
 
 ```ini
 PINECONE_API_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-OPENAI_API_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+GOOGLE_API_KEY = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Optional Gemini configuration overrides
+# GEMINI_MODEL = "gemini-1.5-flash"
+# GEMINI_TEMPERATURE = "0.2"
+# GEMINI_SAFETY_SETTINGS = '{"HARASSMENT":"BLOCK_NONE"}'
 ```
 
 
@@ -54,7 +61,7 @@ open up localhost:
 - Python
 - LangChain
 - Flask
-- GPT
+- Gemini (Google Generative AI)
 - Pinecone
 
 
@@ -127,4 +134,4 @@ open up localhost:
    - AWS_DEFAULT_REGION
    - ECR_REPO
    - PINECONE_API_KEY
-   - OPENAI_API_KEY
+   - GOOGLE_API_KEY

--- a/app.py
+++ b/app.py
@@ -1,12 +1,13 @@
 from flask import Flask, render_template, jsonify, request
 from src.helper import download_hugging_face_embeddings
 from langchain_pinecone import PineconeVectorStore
-from langchain_openai import ChatOpenAI
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain.chains import create_retrieval_chain
 from langchain.chains.combine_documents import create_stuff_documents_chain
 from langchain_core.prompts import ChatPromptTemplate
 from dotenv import load_dotenv
 from src.prompt import *
+import json
 import os
 
 
@@ -15,11 +16,28 @@ app = Flask(__name__)
 
 load_dotenv()
 
-PINECONE_API_KEY=os.environ.get('PINECONE_API_KEY')
-OPENAI_API_KEY=os.environ.get('OPENAI_API_KEY')
+PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY')
+GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
+
+if not PINECONE_API_KEY:
+    raise EnvironmentError("PINECONE_API_KEY is required to run the application.")
+
+if not GOOGLE_API_KEY:
+    raise EnvironmentError("GOOGLE_API_KEY is required to use the Gemini client.")
 
 os.environ["PINECONE_API_KEY"] = PINECONE_API_KEY
-os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
+os.environ["GOOGLE_API_KEY"] = GOOGLE_API_KEY
+
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-1.5-flash")
+GEMINI_TEMPERATURE = float(os.environ.get("GEMINI_TEMPERATURE", "0.2"))
+
+gemini_safety_settings_raw = os.environ.get("GEMINI_SAFETY_SETTINGS")
+gemini_safety_settings = None
+if gemini_safety_settings_raw:
+    try:
+        gemini_safety_settings = json.loads(gemini_safety_settings_raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("GEMINI_SAFETY_SETTINGS must be valid JSON if provided.") from exc
 
 
 embeddings = download_hugging_face_embeddings()
@@ -36,7 +54,15 @@ docsearch = PineconeVectorStore.from_existing_index(
 
 retriever = docsearch.as_retriever(search_type="similarity", search_kwargs={"k":3})
 
-chatModel = ChatOpenAI(model="gpt-4o")
+chat_model_kwargs = {
+    "model": GEMINI_MODEL,
+    "temperature": GEMINI_TEMPERATURE,
+}
+
+if gemini_safety_settings is not None:
+    chat_model_kwargs["safety_settings"] = gemini_safety_settings
+
+chatModel = ChatGoogleGenerativeAI(**chat_model_kwargs)
 prompt = ChatPromptTemplate.from_messages(
     [
         ("system", system_prompt),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 langchain==0.3.26
-flask==3.1.1 
+flask==3.1.1
 sentence-transformers==4.1.0
-pypdf==5.6.1 
+pypdf==5.6.1
 python-dotenv==1.1.0
-langchain-pinecone==0.2.8 
-langchain-openai==0.3.24
+langchain-pinecone==0.2.8
 langchain-community==0.3.26
+langchain-google-genai==2.0.8
+google-generativeai==0.8.4
 -e .

--- a/store_index.py
+++ b/store_index.py
@@ -8,11 +8,12 @@ from langchain_pinecone import PineconeVectorStore
 load_dotenv()
 
 
-PINECONE_API_KEY=os.environ.get('PINECONE_API_KEY')
-OPENAI_API_KEY=os.environ.get('OPENAI_API_KEY')
+PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY')
+
+if not PINECONE_API_KEY:
+    raise EnvironmentError("PINECONE_API_KEY is required to create or update the vector store.")
 
 os.environ["PINECONE_API_KEY"] = PINECONE_API_KEY
-os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 
 extracted_data=load_pdf_file(data='data/')
@@ -42,5 +43,5 @@ index = pc.Index(index_name)
 docsearch = PineconeVectorStore.from_documents(
     documents=text_chunks,
     index_name=index_name,
-    embedding=embeddings, 
+    embedding=embeddings,
 )


### PR DESCRIPTION
## Summary
- replace the OpenAI chat model usage with the Gemini client, reading configuration from environment variables
- remove OpenAI-specific environment handling and provide a template for the new Gemini settings
- refresh the requirements and documentation to cover the Gemini libraries and configuration options

## Testing
- python app.py *(fails: missing langchain_google_genai dependency because packages cannot be installed in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_b_68da28b282b88323964117ffda9a90b4