### PR TITLE
Add session-scoped chat history persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ python store_index.py
 python app.py
 ```
 
+## Persistent chat history
+
+- Conversations are now stored automatically in a SQLite database located at `data/chat_history.sqlite`. Each browser session receives a unique ID so that refreshing the page keeps the prior exchange intact.
+- The `/history` endpoint (session-authenticated) returns the saved turns for the active chat. The chat UI requests this endpoint on load to render previous questions and answers.
+- To reset all saved conversations simply delete the database file:
+
+```bash
+rm -f data/chat_history.sqlite
+```
+
+- Optionally, set a custom Flask secret key when running locally:
+
+```bash
+export FLASK_SECRET_KEY="replace-with-a-secret-value"
+```
+
 Now,
 ```bash
 open up localhost:

--- a/app.py
+++ b/app.py
@@ -1,22 +1,28 @@
-from flask import Flask, render_template, jsonify, request
-from src.helper import download_hugging_face_embeddings
-from langchain_pinecone import PineconeVectorStore
-from langchain_openai import ChatOpenAI
+from flask import Flask, jsonify, render_template, request, session
+from uuid import uuid4
+
+from dotenv import load_dotenv
 from langchain.chains import create_retrieval_chain
 from langchain.chains.combine_documents import create_stuff_documents_chain
-from langchain_core.prompts import ChatPromptTemplate
-from dotenv import load_dotenv
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain_openai import ChatOpenAI
+from langchain_pinecone import PineconeVectorStore
+
+from src.helper import download_hugging_face_embeddings
+from src.history import load_message_history, message_history_factory
 from src.prompt import *
 import os
 
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "change-me")
 
 
 load_dotenv()
 
-PINECONE_API_KEY=os.environ.get('PINECONE_API_KEY')
-OPENAI_API_KEY=os.environ.get('OPENAI_API_KEY')
+PINECONE_API_KEY = os.environ.get("PINECONE_API_KEY")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 
 os.environ["PINECONE_API_KEY"] = PINECONE_API_KEY
 os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
@@ -24,7 +30,7 @@ os.environ["OPENAI_API_KEY"] = OPENAI_API_KEY
 
 embeddings = download_hugging_face_embeddings()
 
-index_name = "medical-chatbot" 
+index_name = "medical-chatbot"
 # Embed each chunk and upsert the embeddings into your Pinecone index.
 docsearch = PineconeVectorStore.from_existing_index(
     index_name=index_name,
@@ -40,6 +46,7 @@ chatModel = ChatOpenAI(model="gpt-4o")
 prompt = ChatPromptTemplate.from_messages(
     [
         ("system", system_prompt),
+        MessagesPlaceholder(variable_name="history"),
         ("human", "{input}"),
     ]
 )
@@ -47,23 +54,49 @@ prompt = ChatPromptTemplate.from_messages(
 question_answer_chain = create_stuff_documents_chain(chatModel, prompt)
 rag_chain = create_retrieval_chain(retriever, question_answer_chain)
 
+conversational_rag = RunnableWithMessageHistory(
+    rag_chain,
+    message_history_factory,
+    input_messages_key="input",
+    history_messages_key="history",
+    output_messages_key="answer",
+)
 
 
 @app.route("/")
 def index():
+    if "conversation_id" not in session:
+        session["conversation_id"] = str(uuid4())
     return render_template('chat.html')
-
 
 
 @app.route("/get", methods=["GET", "POST"])
 def chat():
+    conversation_id = session.get("conversation_id")
+    if not conversation_id:
+        conversation_id = str(uuid4())
+        session["conversation_id"] = conversation_id
     msg = request.form["msg"]
-    input = msg
-    print(input)
-    response = rag_chain.invoke({"input": msg})
+    print(msg)
+    response = conversational_rag.invoke(
+        {"input": msg},
+        config={"configurable": {"session_id": conversation_id}},
+    )
     print("Response : ", response["answer"])
     return str(response["answer"])
 
+
+@app.route("/history", methods=["GET"])
+def history():
+    conversation_id = session.get("conversation_id")
+    if not conversation_id:
+        return jsonify({"error": "Unauthorized"}), 401
+    history_store = load_message_history(conversation_id)
+    messages = [
+        {"role": message.type, "content": message.content}
+        for message in history_store.messages
+    ]
+    return jsonify(messages)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 langchain==0.3.26
-flask==3.1.1 
+flask==3.1.1
 sentence-transformers==4.1.0
-pypdf==5.6.1 
+pypdf==5.6.1
 python-dotenv==1.1.0
-langchain-pinecone==0.2.8 
+langchain-pinecone==0.2.8
 langchain-openai==0.3.24
 langchain-community==0.3.26
+SQLAlchemy==2.0.36
 -e .

--- a/src/history.py
+++ b/src/history.py
@@ -1,0 +1,42 @@
+"""Utilities for managing persistent chat history."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from langchain_community.chat_message_histories import SQLChatMessageHistory
+
+_DB_PATH = Path(os.environ.get("CHAT_HISTORY_DB_PATH", "data/chat_history.sqlite")).expanduser().resolve()
+_CONNECTION_STRING = f"sqlite:///{_DB_PATH}" 
+
+
+def _ensure_storage() -> None:
+    """Ensure that the directory for the history database exists."""
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_message_history(session_id: str) -> SQLChatMessageHistory:
+    """Return the message history for a specific session."""
+    _ensure_storage()
+    return SQLChatMessageHistory(session_id=session_id, connection_string=_CONNECTION_STRING)
+
+
+def message_history_factory(config: Mapping[str, Any] | None) -> SQLChatMessageHistory:
+    """Factory compatible with RunnableWithMessageHistory.
+
+    Args:
+        config: Runnable configuration containing a ``session_id`` in the
+            ``configurable`` namespace.
+
+    Returns:
+        An instance of :class:`SQLChatMessageHistory` bound to the provided session.
+    """
+    session_id = None
+    if config is not None:
+        configurable = config.get("configurable") if isinstance(config, Mapping) else None
+        if isinstance(configurable, Mapping):
+            session_id = configurable.get("session_id")
+    if not session_id:
+        raise ValueError("A session_id must be provided in the runnable configuration.")
+    return load_message_history(str(session_id))

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -48,34 +48,83 @@
 			</div>
 		</div>
 		
-		<script>
-			$(document).ready(function() {
-				$("#messageArea").on("submit", function(event) {
-					const date = new Date();
-					const hour = date.getHours();
-					const minute = date.getMinutes();
-					const str_time = hour+":"+minute;
-					var rawText = $("#text").val();
+                <script>
+                        $(document).ready(function() {
+                                const $messageContainer = $("#messageFormeight");
 
-					var userHtml = '<div class="d-flex justify-content-end mb-4"><div class="msg_cotainer_send">' + rawText + '<span class="msg_time_send">'+ str_time + '</span></div><div class="img_cont_msg"><img src="https://i.ibb.co/d5b84Xw/Untitled-design.png" class="rounded-circle user_img_msg"></div></div>';
-					
-					$("#text").val("");
-					$("#messageFormeight").append(userHtml);
+                                function formatTime(date) {
+                                        return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+                                }
 
-					$.ajax({
-						data: {
-							msg: rawText,	
-						},
-						type: "POST",
-						url: "/get",
-					}).done(function(data) {
-						var botHtml = '<div class="d-flex justify-content-start mb-4"><div class="img_cont_msg"><img src="https://cdn-icons-png.flaticon.com/512/387/387569.png" class="rounded-circle user_img_msg"></div><div class="msg_cotainer">' + data + '<span class="msg_time">' + str_time + '</span></div></div>';
-						$("#messageFormeight").append($.parseHTML(botHtml));
-					});
-					event.preventDefault();
-				});
-			});
-		</script>
+                                function escapeHtml(text) {
+                                        return $("<div>").text(text).html();
+                                }
+
+                                function appendUserMessage(text, time) {
+                                        const timestamp = time || formatTime(new Date());
+                                        const safeText = escapeHtml(text);
+                                        const userHtml = `
+                                                <div class="d-flex justify-content-end mb-4">
+                                                        <div class="msg_cotainer_send">${safeText}<span class="msg_time_send">${timestamp}</span></div>
+                                                        <div class="img_cont_msg"><img src="https://i.ibb.co/d5b84Xw/Untitled-design.png" class="rounded-circle user_img_msg"></div>
+                                                </div>`;
+                                        $messageContainer.append(userHtml);
+                                }
+
+                                function appendBotMessage(text, time) {
+                                        const timestamp = time || formatTime(new Date());
+                                        const safeText = escapeHtml(text);
+                                        const botHtml = `
+                                                <div class="d-flex justify-content-start mb-4">
+                                                        <div class="img_cont_msg"><img src="https://cdn-icons-png.flaticon.com/512/387/387569.png" class="rounded-circle user_img_msg"></div>
+                                                        <div class="msg_cotainer">${safeText}<span class="msg_time">${timestamp}</span></div>
+                                                </div>`;
+                                        $messageContainer.append(botHtml);
+                                }
+
+                                function renderHistory(messages) {
+                                        if (!Array.isArray(messages)) {
+                                                return;
+                                        }
+                                        messages.forEach(function(message) {
+                                                if (message.role === "human") {
+                                                        appendUserMessage(message.content, "");
+                                                } else if (message.role === "ai") {
+                                                        appendBotMessage(message.content, "");
+                                                }
+                                        });
+                                }
+
+                                $.getJSON("/history").done(function(messages) {
+                                        renderHistory(messages);
+                                }).fail(function() {
+                                        console.warn("Unable to load previous conversation history.");
+                                });
+
+                                $("#messageArea").on("submit", function(event) {
+                                        event.preventDefault();
+                                        const rawText = $("#text").val();
+                                        if (!rawText) {
+                                                return;
+                                        }
+
+                                        $("#text").val("");
+                                        appendUserMessage(rawText);
+
+                                        $.ajax({
+                                                data: {
+                                                        msg: rawText,
+                                                },
+                                                type: "POST",
+                                                url: "/get",
+                                        }).done(function(data) {
+                                                appendBotMessage(data);
+                                        }).fail(function() {
+                                                appendBotMessage("Sorry, I ran into a problem. Please try again.");
+                                        });
+                                });
+                        });
+                </script>
         
     </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce a SQLite-backed chat history helper and wire the RAG chain through RunnableWithMessageHistory
- persist session-scoped conversations via Flask sessions, including a new /history endpoint for retrieving messages
- preload saved messages in the chat UI and document the new behaviour and dependencies

## Testing
- python -m compileall src app.py

------
https://chatgpt.com/codex/tasks/task_b_68da28b75c7083239498c759e5f1a4da