### PR TITLE
Update langchain imports and session history handling

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -1,17 +1,19 @@
-from langchain.document_loaders import PyPDFLoader, DirectoryLoader
+from langchain_community.document_loaders import DirectoryLoader, PyPDFLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.embeddings import HuggingFaceEmbeddings
+from langchain_community.embeddings import HuggingFaceEmbeddings
 from typing import List
 from langchain.schema import Document
 
 
-#Extract Data From the PDF File
+# Extract Data From the PDF File
 def load_pdf_file(data):
-    loader= DirectoryLoader(data,
-                            glob="*.pdf",
-                            loader_cls=PyPDFLoader)
+    loader = DirectoryLoader(
+        data,
+        glob="*.pdf",
+        loader_cls=PyPDFLoader,
+    )
 
-    documents=loader.load()
+    documents = loader.load()
 
     return documents
 
@@ -35,15 +37,17 @@ def filter_to_minimal_docs(docs: List[Document]) -> List[Document]:
 
 
 
-#Split the Data into Text Chunks
+# Split the Data into Text Chunks
 def text_split(extracted_data):
-    text_splitter=RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=20)
-    text_chunks=text_splitter.split_documents(extracted_data)
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=20)
+    text_chunks = text_splitter.split_documents(extracted_data)
     return text_chunks
 
 
 
-#Download the Embeddings from HuggingFace 
+# Download the Embeddings from HuggingFace
 def download_hugging_face_embeddings():
-    embeddings=HuggingFaceEmbeddings(model_name='sentence-transformers/all-MiniLM-L6-v2')  #this model return 384 dimensions
+    embeddings = HuggingFaceEmbeddings(
+        model_name="sentence-transformers/all-MiniLM-L6-v2"
+    )  # this model return 384 dimensions
     return embeddings

--- a/src/history.py
+++ b/src/history.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping
 from langchain_community.chat_message_histories import SQLChatMessageHistory
 
 _DB_PATH = Path(os.environ.get("CHAT_HISTORY_DB_PATH", "data/chat_history.sqlite")).expanduser().resolve()
-_CONNECTION_STRING = f"sqlite:///{_DB_PATH}" 
+_CONNECTION_STRING = f"sqlite:///{_DB_PATH}"
 
 
 def _ensure_storage() -> None:
@@ -19,7 +19,7 @@ def _ensure_storage() -> None:
 def load_message_history(session_id: str) -> SQLChatMessageHistory:
     """Return the message history for a specific session."""
     _ensure_storage()
-    return SQLChatMessageHistory(session_id=session_id, connection_string=_CONNECTION_STRING)
+    return SQLChatMessageHistory(session_id=session_id, connection=_CONNECTION_STRING)
 
 
 def message_history_factory(config: Mapping[str, Any] | None) -> SQLChatMessageHistory:
@@ -34,9 +34,14 @@ def message_history_factory(config: Mapping[str, Any] | None) -> SQLChatMessageH
     """
     session_id = None
     if config is not None:
-        configurable = config.get("configurable") if isinstance(config, Mapping) else None
+        if isinstance(config, Mapping):
+            configurable = config.get("configurable")
+        else:
+            configurable = getattr(config, "configurable", None)
         if isinstance(configurable, Mapping):
             session_id = configurable.get("session_id")
+        else:
+            session_id = getattr(configurable, "session_id", None)
     if not session_id:
         raise ValueError("A session_id must be provided in the runnable configuration.")
     return load_message_history(str(session_id))


### PR DESCRIPTION
## Summary
- replace deprecated document loader and embedding imports with langchain_community equivalents and clean up helper formatting
- update chat history management to use the new connection parameter and accept RunnableConfig objects when retrieving the session id

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68da35f7aa1c8323b930dcd86352d55f