### PR TITLE
Add conversational memory and refresh chat UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,9 +2,14 @@ from flask import Flask, render_template, jsonify, request
 from src.helper import download_hugging_face_embeddings
 from langchain_pinecone import PineconeVectorStore
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain.chains import create_retrieval_chain
+from langchain.chains import (
+    create_history_aware_retriever,
+    create_retrieval_chain,
+)
 from langchain.chains.combine_documents import create_stuff_documents_chain
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.chat_history import ChatMessageHistory
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.runnables.history import RunnableWithMessageHistory
 from dotenv import load_dotenv
 from src.prompt import *
 import json
@@ -63,15 +68,55 @@ if gemini_safety_settings is not None:
     chat_model_kwargs["safety_settings"] = gemini_safety_settings
 
 chatModel = ChatGoogleGenerativeAI(**chat_model_kwargs)
+
+contextualize_q_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a helpful AI assistant. Given a chat history and the latest user"
+            " question which might reference context in the history, rewrite the"
+            " question to be a standalone query. If no rewriting is needed, return"
+            " the question as-is.",
+        ),
+        MessagesPlaceholder("chat_history"),
+        ("human", "{input}"),
+    ]
+)
+
+history_aware_retriever = create_history_aware_retriever(
+    chatModel, retriever, contextualize_q_prompt
+)
+
 prompt = ChatPromptTemplate.from_messages(
     [
-        ("system", system_prompt),
+        (
+            "system",
+            system_prompt + "\n\nRelevant context from medical literature:\n{context}",
+        ),
+        MessagesPlaceholder("chat_history"),
         ("human", "{input}"),
     ]
 )
 
 question_answer_chain = create_stuff_documents_chain(chatModel, prompt)
-rag_chain = create_retrieval_chain(retriever, question_answer_chain)
+rag_chain = create_retrieval_chain(history_aware_retriever, question_answer_chain)
+
+session_store = {}
+
+
+def get_session_history(session_id: str) -> ChatMessageHistory:
+    if session_id not in session_store:
+        session_store[session_id] = ChatMessageHistory()
+    return session_store[session_id]
+
+
+conversational_rag_chain = RunnableWithMessageHistory(
+    rag_chain,
+    get_session_history,
+    input_messages_key="input",
+    history_messages_key="chat_history",
+    output_messages_key="answer",
+)
 
 
 
@@ -83,12 +128,23 @@ def index():
 
 @app.route("/get", methods=["GET", "POST"])
 def chat():
-    msg = request.form["msg"]
-    input = msg
-    print(input)
-    response = rag_chain.invoke({"input": msg})
-    print("Response : ", response["answer"])
-    return str(response["answer"])
+    data = request.get_json(silent=True) or request.form
+    msg = data.get("msg") if data else None
+    if not msg:
+        return jsonify({"error": "Message is required."}), 400
+
+    session_id = (
+        data.get("session_id")
+        if isinstance(data, dict)
+        else request.form.get("session_id")
+    ) or request.remote_addr
+
+    response = conversational_rag_chain.invoke(
+        {"input": msg},
+        config={"configurable": {"session_id": session_id}},
+    )
+    answer = response.get("answer", "")
+    return jsonify({"answer": answer})
 
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -1,223 +1,347 @@
-body,html{
-	height: 100%;
-	margin: 0;
-	background: rgb(44, 47, 59);
-   background: -webkit-linear-gradient(to right, rgb(40, 59, 34), rgb(54, 60, 70), rgb(32, 32, 43));
-	background: linear-gradient(to right, rgb(38, 51, 61), rgb(50, 55, 65), rgb(33, 33, 78));
+:root {
+  color-scheme: dark;
+  --bg-gradient-start: #0b1f36;
+  --bg-gradient-end: #121826;
+  --card-bg: rgba(17, 29, 46, 0.75);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --user-bubble: #34d399;
+  --assistant-bubble: #1d4ed8;
+  --border: rgba(148, 163, 184, 0.2);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-.chat{
-	margin-top: auto;
-	margin-bottom: auto;
+* {
+  box-sizing: border-box;
 }
-.card{
-	height: 500px;
-	border-radius: 15px !important;
-	background-color: rgba(0,0,0,0.4) !important;
-}
-.contacts_body{
-	padding:  0.75rem 0 !important;
-	overflow-y: auto;
-	white-space: nowrap;
-}
-.msg_card_body{
-	overflow-y: auto;
-}
-.card-header{
-	border-radius: 15px 15px 0 0 !important;
-	border-bottom: 0 !important;
-}
-.card-footer{
-border-radius: 0 0 15px 15px !important;
-	border-top: 0 !important;
-}
-.container{
-	align-content: center;
-}
-.search{
-	border-radius: 15px 0 0 15px !important;
-	background-color: rgba(0,0,0,0.3) !important;
-	border:0 !important;
-	color:white !important;
-}
-.search:focus{
-	 box-shadow:none !important;
-   outline:0px !important;
-}
-.type_msg{
-	background-color: rgba(0,0,0,0.3) !important;
-	border:0 !important;
-	color:white !important;
-	height: 60px !important;
-	overflow-y: auto;
-}
-	.type_msg:focus{
-	 box-shadow:none !important;
-   outline:0px !important;
-}
-.attach_btn{
-	border-radius: 15px 0 0 15px !important;
-	background-color: rgba(0,0,0,0.3) !important;
-	border:0 !important;
-	color: white !important;
-	cursor: pointer;
-}
-.send_btn{
-	border-radius: 0 15px 15px 0 !important;
-	background-color: rgba(0,0,0,0.3) !important;
-	border:0 !important;
-	color: white !important;
-	cursor: pointer;
-}
-.search_btn{
-	border-radius: 0 15px 15px 0 !important;
-	background-color: rgba(0,0,0,0.3) !important;
-	border:0 !important;
-	color: white !important;
-	cursor: pointer;
-}
-.contacts{
-	list-style: none;
-	padding: 0;
-}
-.contacts li{
-	width: 100% !important;
-	padding: 5px 10px;
-	margin-bottom: 15px !important;
-}
-.active{
-	background-color: rgba(0,0,0,0.3);
-}
-.user_img{
-	height: 70px;
-	width: 70px;
-	border:1.5px solid #f5f6fa;
 
+html,
+body {
+  height: 100%;
+  margin: 0;
+  background: linear-gradient(160deg, var(--bg-gradient-start), var(--bg-gradient-end));
+  color: var(--text-primary);
 }
-.user_img_msg{
-	height: 40px;
-	width: 40px;
-	border:1.5px solid #f5f6fa;
 
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
 }
-.img_cont{
-	position: relative;
-	height: 70px;
-	width: 70px;
+
+.app-shell {
+  width: min(960px, 100%);
 }
-.img_cont_msg{
-	height: 40px;
-	width: 40px;
+
+.chat-panel {
+  background: var(--card-bg);
+  border-radius: 24px;
+  box-shadow: 0 40px 80px rgba(8, 47, 73, 0.35);
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  gap: 1.5rem;
+  border: 1px solid var(--border);
+  backdrop-filter: blur(12px);
 }
-.online_icon{
-	position: absolute;
-	height: 15px;
-	width:15px;
-	background-color: #4cd137;
-	border-radius: 50%;
-	bottom: 0.2em;
-	right: 0.4em;
-	border:1.5px solid white;
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
-.offline{
-	background-color: #c23616 !important;
+
+.chat-header h1 {
+  font-size: clamp(1.5rem, 3vw, 1.875rem);
+  margin: 0;
 }
-.user_info{
-	margin-top: auto;
-	margin-bottom: auto;
-	margin-left: 15px;
+
+.chat-header p {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
 }
-.user_info span{
-	font-size: 20px;
-	color: white;
+
+.avatar {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: rgba(59, 130, 246, 0.2);
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(59, 130, 246, 0.4);
 }
-.user_info p{
-	font-size: 10px;
-	color: rgba(255,255,255,0.6);
+
+.avatar img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
 }
-.video_cam{
-	margin-left: 50px;
-	margin-top: 5px;
+
+.status-dot {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #22c55e;
+  border: 2px solid var(--card-bg);
+  box-shadow: 0 0 12px rgba(34, 197, 94, 0.65);
 }
-.video_cam span{
-	color: white;
-	font-size: 20px;
-	cursor: pointer;
-	margin-right: 20px;
+
+.message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-height: min(60vh, 600px);
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  scroll-behavior: smooth;
 }
-.msg_cotainer{
-	margin-top: auto;
-	margin-bottom: auto;
-	margin-left: 10px;
-	border-radius: 25px;
-	background-color: rgb(82, 172, 255);
-	padding: 10px;
-	position: relative;
+
+.message-list::-webkit-scrollbar {
+  width: 6px;
 }
-.msg_cotainer_send{
-	margin-top: auto;
-	margin-bottom: auto;
-	margin-right: 10px;
-	border-radius: 25px;
-	background-color: #58cc71;
-	padding: 10px;
-	position: relative;
+
+.message-list::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
 }
-.msg_time{
-	position: absolute;
-	left: 0;
-	bottom: -15px;
-	color: rgba(255,255,255,0.5);
-	font-size: 10px;
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  animation: fade-in-up 0.35s ease;
 }
-.msg_time_send{
-	position: absolute;
-	right:0;
-	bottom: -15px;
-	color: rgba(255,255,255,0.5);
-	font-size: 10px;
+
+.message[data-role="user"] {
+  align-items: flex-end;
 }
-.msg_head{
-	position: relative;
+
+.message[data-role="assistant"] {
+  align-items: flex-start;
 }
-#action_menu_btn{
-	position: absolute;
-	right: 10px;
-	top: 10px;
-	color: white;
-	cursor: pointer;
-	font-size: 20px;
+
+.message-meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
 }
-.action_menu{
-	z-index: 1;
-	position: absolute;
-	padding: 15px 0;
-	background-color: rgba(0,0,0,0.5);
-	color: white;
-	border-radius: 15px;
-	top: 30px;
-	right: 15px;
-	display: none;
+
+.message-bubble {
+  padding: 1rem 1.15rem;
+  border-radius: 18px;
+  line-height: 1.55;
+  max-width: clamp(260px, 70%, 520px);
+  word-wrap: break-word;
+  white-space: pre-line;
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
 }
-.action_menu ul{
-	list-style: none;
-	padding: 0;
-	margin: 0;
+
+.message[data-role="user"] .message-bubble {
+  background: var(--user-bubble);
+  color: #052e16;
+  border-bottom-right-radius: 4px;
 }
-.action_menu ul li{
-	width: 100%;
-	padding: 10px 15px;
-	margin-bottom: 5px;
+
+.message[data-role="assistant"] .message-bubble {
+  background: rgba(29, 78, 216, 0.75);
+  color: #e0f2fe;
+  border-bottom-left-radius: 4px;
 }
-.action_menu ul li i{
-	padding-right: 10px;
+
+.suggestions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
 }
-.action_menu ul li:hover{
-	cursor: pointer;
-	background-color: rgba(0,0,0,0.2);
+
+.suggestions button {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--text-primary);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
-@media(max-width: 576px){
-	.contacts_card{
-	margin-bottom: 15px !important;
+
+.suggestions button:hover,
+.suggestions button:focus-visible {
+  outline: none;
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-2px);
+  box-shadow: 0 20px 35px rgba(14, 165, 233, 0.25);
 }
+
+.typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  padding: 0.75rem 1rem;
+  width: fit-content;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.typing-indicator.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.typing-indicator span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pulse 1s ease infinite;
+}
+
+.typing-indicator span:nth-child(2) {
+  animation-delay: 0.1s;
+}
+
+.typing-indicator span:nth-child(3) {
+  animation-delay: 0.2s;
+}
+
+.typing-indicator p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.message-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.35);
+  border-radius: 18px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.message-form textarea {
+  flex: 1;
+  resize: none;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 1rem;
+  line-height: 1.55;
+  max-height: 160px;
+}
+
+.message-form textarea::placeholder {
+  color: rgba(148, 163, 184, 0.55);
+}
+
+.message-form textarea:focus {
+  outline: none;
+}
+
+.message-form button {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+  border: none;
+  border-radius: 14px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.message-form button:hover,
+.message-form button:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(14, 165, 233, 0.35);
+}
+
+.message-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.message-form button.is-loading::after {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(15, 23, 42, 0.3);
+  border-top-color: rgba(15, 23, 42, 0.85);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.3;
+  }
+  30% {
+    transform: translateY(-2px);
+    opacity: 1;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .chat-panel {
+    border-radius: 18px;
+    padding: 1.5rem;
+  }
+
+  .suggestions {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
 }

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,81 +1,200 @@
-<link href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" rel="stylesheet" id="bootstrap-css">
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-
 <!DOCTYPE html>
-<html>
-	<head>
-		<title>Chatbot</title>
-		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
-		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-		<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css')}}"/>
-	</head>
-	
-	
-	<body>
-		<div class="container-fluid h-100">
-			<div class="row justify-content-center h-100">		
-				<div class="col-md-8 col-xl-6 chat">
-					<div class="card">
-						<div class="card-header msg_head">
-							<div class="d-flex bd-highlight">
-								<div class="img_cont">
-									<img src="https://cdn-icons-png.flaticon.com/512/387/387569.png" class="rounded-circle user_img">
-									<!-- <img src="https://www.prdistribution.com/spirit/uploads/pressreleases/2019/newsreleases/d83341deb75c4c4f6b113f27b1e42cd8-chatbot-florence-already-helps-thousands-of-patients-to-remember-their-medication.png" class="rounded-circle user_img"> -->
-									<span class="online_icon"></span>
-								</div>
-								<div class="user_info">
-									<span>Medical Chatbot</span>
-									<p>Ask me anything!</p>
-								</div>
-							</div>
-						</div>
-						<div id="messageFormeight" class="card-body msg_card_body">
-							
-							
-						</div>
-						<div class="card-footer">
-							<form id="messageArea" class="input-group">
-                                <input type="text" id="text" name="msg" placeholder="Type your message..." autocomplete="off" class="form-control type_msg" required/>
-								<div class="input-group-append">
-									<button type="submit" id="send" class="input-group-text send_btn"><i class="fas fa-location-arrow"></i></button>
-								</div>
-							</form>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-		
-		<script>
-			$(document).ready(function() {
-				$("#messageArea").on("submit", function(event) {
-					const date = new Date();
-					const hour = date.getHours();
-					const minute = date.getMinutes();
-					const str_time = hour+":"+minute;
-					var rawText = $("#text").val();
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HealthBridge Assistant</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='style.css')}}" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <section class="chat-panel">
+        <header class="chat-header">
+          <div class="avatar">
+            <img
+              src="https://cdn-icons-png.flaticon.com/512/387/387569.png"
+              alt="HealthBridge Assistant"
+            />
+            <span class="status-dot" aria-hidden="true"></span>
+          </div>
+          <div>
+            <h1>HealthBridge Assistant</h1>
+            <p>Your personal medical research companion</p>
+          </div>
+        </header>
 
-					var userHtml = '<div class="d-flex justify-content-end mb-4"><div class="msg_cotainer_send">' + rawText + '<span class="msg_time_send">'+ str_time + '</span></div><div class="img_cont_msg"><img src="https://i.ibb.co/d5b84Xw/Untitled-design.png" class="rounded-circle user_img_msg"></div></div>';
-					
-					$("#text").val("");
-					$("#messageFormeight").append(userHtml);
+        <div id="messageList" class="message-list" role="log" aria-live="polite"></div>
 
-					$.ajax({
-						data: {
-							msg: rawText,	
-						},
-						type: "POST",
-						url: "/get",
-					}).done(function(data) {
-						var botHtml = '<div class="d-flex justify-content-start mb-4"><div class="img_cont_msg"><img src="https://cdn-icons-png.flaticon.com/512/387/387569.png" class="rounded-circle user_img_msg"></div><div class="msg_cotainer">' + data + '<span class="msg_time">' + str_time + '</span></div></div>';
-						$("#messageFormeight").append($.parseHTML(botHtml));
-					});
-					event.preventDefault();
-				});
-			});
-		</script>
-        
-    </body>
+        <div class="suggestions" id="suggestionList" aria-label="Suggested prompts">
+          <button type="button" data-suggestion="What are the symptoms of anemia?">Symptoms of anemia</button>
+          <button type="button" data-suggestion="How can I improve my sleep hygiene?">Improve sleep hygiene</button>
+          <button type="button" data-suggestion="Explain the recommended diet for managing diabetes.">Diet for diabetes</button>
+        </div>
+
+        <div class="typing-indicator" id="typingIndicator" hidden>
+          <span></span>
+          <span></span>
+          <span></span>
+          <p>HealthBridge is formulating a response…</p>
+        </div>
+
+        <form id="messageForm" class="message-form" autocomplete="off">
+          <label class="sr-only" for="userMessage">Type your message</label>
+          <textarea
+            id="userMessage"
+            name="msg"
+            placeholder="Ask a medical question or describe your symptoms..."
+            rows="1"
+            required
+          ></textarea>
+          <button type="submit" id="sendButton" aria-label="Send message">
+            <span>Send</span>
+          </button>
+        </form>
+      </section>
+    </main>
+
+    <template id="messageTemplate">
+      <div class="message" data-role="">
+        <div class="message-meta">
+          <span class="message-author"></span>
+          <time class="message-time"></time>
+        </div>
+        <div class="message-bubble"></div>
+      </div>
+    </template>
+
+    <script>
+      const form = document.getElementById("messageForm");
+      const messageInput = document.getElementById("userMessage");
+      const messageList = document.getElementById("messageList");
+      const typingIndicator = document.getElementById("typingIndicator");
+      const suggestionList = document.getElementById("suggestionList");
+      const messageTemplate = document.getElementById("messageTemplate");
+
+      const sessionKey = "healthbridge-session";
+      let sessionId = localStorage.getItem(sessionKey);
+      if (!sessionId) {
+        sessionId = crypto.randomUUID();
+        localStorage.setItem(sessionKey, sessionId);
+      }
+
+      const sendButton = document.getElementById("sendButton");
+
+      const setButtonState = (state) => {
+        sendButton.disabled = state;
+        sendButton.classList.toggle("is-loading", state);
+      };
+
+      const autoResize = (target) => {
+        target.style.height = "auto";
+        target.style.height = `${Math.min(target.scrollHeight, 160)}px`;
+      };
+
+      const createMessage = (role, text, allowHtml = false) => {
+        const element = messageTemplate.content.firstElementChild.cloneNode(true);
+        element.dataset.role = role;
+        element.querySelector(".message-author").textContent =
+          role === "user" ? "You" : "HealthBridge";
+        element.querySelector(".message-time").textContent = new Date().toLocaleTimeString([], {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+        const bubble = element.querySelector(".message-bubble");
+        if (allowHtml) {
+          bubble.innerHTML = text;
+        } else {
+          bubble.textContent = text;
+        }
+        return element;
+      };
+
+      const appendMessage = (role, text, options = {}) => {
+        const message = createMessage(role, text, options.allowHtml);
+        messageList.appendChild(message);
+        messageList.scrollTo({ top: messageList.scrollHeight, behavior: "smooth" });
+      };
+
+      const toggleTypingIndicator = (isVisible) => {
+        typingIndicator.hidden = !isVisible;
+        typingIndicator.classList.toggle("visible", isVisible);
+      };
+
+      messageInput.addEventListener("input", (event) => {
+        autoResize(event.target);
+        setButtonState(!event.target.value.trim());
+      });
+
+      suggestionList.addEventListener("click", (event) => {
+        const suggestion = event.target.dataset?.suggestion;
+        if (!suggestion) return;
+        messageInput.value = suggestion;
+        autoResize(messageInput);
+        setButtonState(false);
+        messageInput.focus();
+      });
+
+      const sendMessage = async (text) => {
+        appendMessage("user", text);
+        toggleTypingIndicator(true);
+
+        try {
+          const response = await fetch("/get", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ msg: text, session_id: sessionId }),
+          });
+
+          const data = await response.json();
+          if (!response.ok) {
+            throw new Error(data.error || "Unable to get a response");
+          }
+
+          appendMessage("assistant", data.answer.trim());
+        } catch (error) {
+          appendMessage(
+            "assistant",
+            `I ran into an issue processing that request. Please try again.\n\nDetails: ${error.message}`
+          );
+        } finally {
+          toggleTypingIndicator(false);
+        }
+      };
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const text = messageInput.value.trim();
+        if (!text) return;
+
+        setButtonState(true);
+        messageInput.value = "";
+        autoResize(messageInput);
+
+        sendMessage(text).finally(() => {
+          setButtonState(false);
+        });
+      });
+
+      // Prime the interface with a welcome message
+      appendMessage(
+        "assistant",
+        "Hello! I'm HealthBridge, your companion for navigating medical information. How can I support you today?"
+      );
+
+      setButtonState(true);
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add history-aware retrieval chain so responses consider prior turns per session
- accept session identifiers in the chat endpoint and return JSON payloads for the UI
- redesign the chat experience with responsive styling, suggestions, and typing feedback

## Testing
- python -m compileall app.py templates/chat.html static/style.css

------
https://chatgpt.com/codex/tasks/task_b_68da5925e0148323899c5080a2e9faad